### PR TITLE
Point BSS Region to ram0 instead of ram1 (#74)

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR-DEBUG.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/STM32F746xG_CLR-DEBUG.ld
@@ -71,7 +71,7 @@ REGION_ALIAS("DATA_RAM", ram0);
 REGION_ALIAS("DATA_RAM_LMA", flash);
 
 /* RAM region to be used for BSS segment.*/
-REGION_ALIAS("BSS_RAM", ram1);
+REGION_ALIAS("BSS_RAM", ram0);
 
 /* RAM region to be used for the default heap.*/
 REGION_ALIAS("HEAP_RAM", ram3);


### PR DESCRIPTION
#ST_NUCLEO144_F746ZG#

Signed-off-by: piwi1263 <piwi1263@gmail.com>

<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes/Closes/Resolves nanoFramework/Home#NNNN
<!--- to request a build for a specific target include the target name inside '#' like this #I2M_OXYGEN_NF#, multiple targets can be build just add the respective token -->
<!--- to build all the targets use #ALL# -->
